### PR TITLE
fix: update urls in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "doubtfire-web"]
 	path = doubtfire-web
-	url = git@github.com:thoth-tech/doubtfire-web.git
+	url = https://github.com/thoth-tech/doubtfire-web.git
 [submodule "doubtfire-api"]
 	path = doubtfire-api
-	url = git@github.com:thoth-tech/doubtfire-api.git
+	url = https://github.com/thoth-tech/doubtfire-api.git
 [submodule "doubtfire-overseer"]
 	path = doubtfire-overseer
-	url = https://github.com/doubtfire-lms/doubtfire-overseer.git
+	url = https://github.com/thoth-tech/doubtfire-overseer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "doubtfire-web"]
 	path = doubtfire-web
-	url = https://github.com/doubtfire-lms/doubtfire-web.git
+	url = git@github.com:thoth-tech/doubtfire-web.git
 [submodule "doubtfire-api"]
 	path = doubtfire-api
-	url = https://github.com/doubtfire-lms/doubtfire-api.git
+	url = git@github.com:thoth-tech/doubtfire-api.git
 [submodule "doubtfire-overseer"]
 	path = doubtfire-overseer
 	url = https://github.com/doubtfire-lms/doubtfire-overseer.git


### PR DESCRIPTION
# Description

The URLs to the doubtfire submodules in .gitmodules have been updated to point to the thoth-tech repo instead of doubtfire-lms.

Fixes # (doubtfire submodules origin not pointing to the thoth-tech repo)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

In doubtfire-deploy, run `git submodule sync`. 
Next, in doubtfire-web, run `git remote -v` to confirm origin points to `https://github.com/thoth-tech/doubtfire-web.git`. Do the same for doubtfire-api to confirm origin points to `https://github.com/thoth-tech/doubtfire-api.git`, and doubtfire-overseer: `https://github.com/thoth-tech/doubtfire-overseer.git`

## Testing Checklist:

- [X] Tested in Git/Terminal

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from Tan Le & Ray Guo on the Pull Request
