### PR TITLE
Fix: change_remotes.sh script to point to current upstream

### DIFF
--- a/change_remotes.sh
+++ b/change_remotes.sh
@@ -30,8 +30,8 @@ function setup_remote {
   # Adding failure message if origin is not updated
   ORIGIN_URL="https://github.com/${GH_USER}/${PROJECT}.git" || echo "Script has ailed to set origin for $PROJECT"
 
-  # Updating upstream to current thoth-tech repository location and failure message if upstream is not updated
-  UPSTREAM_URL="https://github.com/thoth-tech/${PROJECT}.git" || echo "Script has ailed to set upstream for $PROJECT"
+  # Updating upstream to current repo location and failure message if upstream is not updated
+  UPSTREAM_URL="https://github.com/doubtfire-lms/${PROJECT}.git" || echo "Script has ailed to set upstream for $PROJECT"
 
   # Changing output to changing as it will output "echo " - origin is now $ORIGIN_URL"" whether it succeeds or fails 
   echo "Setting up $PROJECT"

--- a/change_remotes.sh
+++ b/change_remotes.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
-APP_PATH=`cd "$APP_PATH"; pwd`
+# Updating file path logic to work in mac, linux, and windows with git bash, doesn't break
+APP_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd "${APP_PATH}"
 
 echo "This script will automate the process of switching remote for the Doubtfire deploy project and submodules"
 echo "At the end of this process you will have a origin referring to your fork, and upstream referring to the"
-echo "doubtfire-lms organisation root for the project."
+echo "thoth-tech organisation root for the project." # Updating output to thoth-tech not doubtfire-lms to reflect repository
 echo
 
 read -p "What is your github username: " GH_USER
@@ -18,14 +18,25 @@ function setup_remote {
   PROJECT=$1
   PROJECT_PATH=$2
 
+  # Adding logic if file path does not exist
+  cd "$PROJECT_PATH" || {
+    echo "The directory $PROJECT_PATH does not exist. Skipping $PROJECT"
+    echo
+    return
+  }
+
   cd "$PROJECT_PATH"
 
-  ORIGIN_URL="https://github.com/${GH_USER}/${PROJECT}.git"
-  UPSTREAM_URL="https://github.com/doubtfire-lms/${PROJECT}.git"
+  # Adding failure message if origin is not updated
+  ORIGIN_URL="https://github.com/${GH_USER}/${PROJECT}.git" || echo "Script has ailed to set origin for $PROJECT"
 
+  # Updating upstream to current thoth-tech repository location and failure message if upstream is not updated
+  UPSTREAM_URL="https://github.com/thoth-tech/${PROJECT}.git" || echo "Script has ailed to set upstream for $PROJECT"
+
+  # Changing output to changing as it will output "echo " - origin is now $ORIGIN_URL"" whether it succeeds or fails 
   echo "Setting up $PROJECT"
-  echo " - origin is now $ORIGIN_URL"
-  echo " - upstream is now $UPSTREAM_URL"
+  echo " - Changing origin to $ORIGIN_URL"
+  echo " - Changing upstream to $UPSTREAM_URL"
   echo
 
   git remote set-url origin "$ORIGIN_URL"

--- a/change_remotes.sh
+++ b/change_remotes.sh
@@ -28,10 +28,10 @@ function setup_remote {
   cd "$PROJECT_PATH"
 
   # Adding failure message if origin is not updated
-  ORIGIN_URL="https://github.com/${GH_USER}/${PROJECT}.git" || echo "Script has ailed to set origin for $PROJECT"
+  ORIGIN_URL="https://github.com/${GH_USER}/${PROJECT}.git" || echo "Script has failed to set origin for $PROJECT"
 
   # Updating upstream to current thoth-tech repository location and failure message if upstream is not updated
-  UPSTREAM_URL="https://github.com/thoth-tech/${PROJECT}.git" || echo "Script has ailed to set upstream for $PROJECT"
+  UPSTREAM_URL="https://github.com/thoth-tech/${PROJECT}.git" || echo "Script has failed to set upstream for $PROJECT"
 
   # Changing output to changing as it will output "echo " - origin is now $ORIGIN_URL"" whether it succeeds or fails 
   echo "Setting up $PROJECT"

--- a/change_remotes.sh
+++ b/change_remotes.sh
@@ -30,13 +30,8 @@ function setup_remote {
   # Adding failure message if origin is not updated
   ORIGIN_URL="https://github.com/${GH_USER}/${PROJECT}.git" || echo "Script has failed to set origin for $PROJECT"
 
-<<<<<<< HEAD
   # Updating upstream to current repo location and failure message if upstream is not updated
   UPSTREAM_URL="https://github.com/doubtfire-lms/${PROJECT}.git" || echo "Script has ailed to set upstream for $PROJECT"
-=======
-  # Updating upstream to current thoth-tech repository location and failure message if upstream is not updated
-  UPSTREAM_URL="https://github.com/thoth-tech/${PROJECT}.git" || echo "Script has failed to set upstream for $PROJECT"
->>>>>>> 358e788f445bd2fb5233c591544693950f99e0f6
 
   # Changing output to changing as it will output "echo " - origin is now $ORIGIN_URL"" whether it succeeds or fails 
   echo "Setting up $PROJECT"


### PR DESCRIPTION
# Description
Updating the change_remotes.sh script to correct filepath logic and to toth-tech upstream instead of previous doubtfire-lms upstream to match Satika's setup video guide

https://github.com/thoth-tech/doubtfire-deploy/blob/main/CONTRIBUTING.md
Step 4 will now work correctly

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran multiple tests to ensure correct origin and upstream are set as well as potential errors to be caught if some repositories are missing and updating text 

## Testing Checklist:

- [x] Tested in git bash on Windows (My only OS)
- [ ] Tested on Mac
- [ ] Tested on Linux

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @macite and @jakerenzella on the Pull Request