### PR TITLE
app-attack-fixes/clickjacking vulnerability

### DIFF
--- a/production/shared-files/proxy-nginx.conf
+++ b/production/shared-files/proxy-nginx.conf
@@ -31,6 +31,11 @@ http {
         ssl_certificate     /etc/nginx/cert.crt;
         ssl_certificate_key /etc/nginx/key.key;
 
+        # Security Headers added here to Prevent Clickjacking
+        add_header X-Frame-Options "DENY" always;
+        add_header Content-Security-Policy "default-src 'self'; frame-ancestors 'none';" always;
+        #Mentioning headers to prevent XSS attacks and not to load any <iframe> on to the page
+
         # All api requests go to rails server
         location /api {
           proxy_set_header        Host $host;


### PR DESCRIPTION
_Base Branch: app-attack-fixes_

_Note: Making a PR to doubtfire-deploy so that this can be merged asap, and HardHat leads can retest this fix._

# Description

- _This PR addresses **Clickjacking and potential XSS vulnerabilities** by adding appropriate security headers to the `proxy-nginx.conf` file used in production. These headers are now enforced at the outer reverse proxy layer (`doubtfire-deploy`) to ensure consistent protection across all services._
- _The changes follow recommendations from the AppAttack x OnTrack vulnerability report and align with security best practices for modern web applications._

### Note

_Kindly go through the attached [documentation ](https://github.com/thoth-tech/documentation/pull/593) first inorder to understand what this fix is about in detail and how it can be tested._

## What was changed:
- Modified: `production/shared-files/proxy-nginx.conf`

Fixes # (_Clickjacking vulnerability (AppAttack finding)_)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Used browser DevTools to inspect headers returned for application responses
- Yet to test Clickjacking Prevention in a Malicious <Iframe> Setup as listed in the report.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Needs to be tested inside a dedicated environment like kali linux inside a virtual box.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

**Note:** This PR should be merged in sync with the corresponding PR in [`doubtfire-web`](https://github.com/thoth-tech/doubtfire-web/pull/321) where redundant headers are commented out to prevent override.
