### PR TITLE
Update change_remotes.sh

### DIFF
--- a/change_remotes.sh
+++ b/change_remotes.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
-APP_PATH=`echo $0 | awk '{split($0,patharr,"/"); idx=1; while(patharr[idx+1] != "") { if (patharr[idx] != "/") {printf("%s/", patharr[idx]); idx++ }} }'`
-APP_PATH=`cd "$APP_PATH"; pwd`
+# Updating file path logic to work in mac, linux, and windows with git bash, doesn't break
+APP_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd "${APP_PATH}"
 
 echo "This script will automate the process of switching remote for the Doubtfire deploy project and submodules"
 echo "At the end of this process you will have a origin referring to your fork, and upstream referring to the"
-echo "doubtfire-lms organisation root for the project."
+echo "source of the project."
 echo
 
 read -p "What is your github username: " GH_USER
+read -p "What is your upstream repository: " UPSTREAM
 
 echo
 
@@ -18,14 +19,25 @@ function setup_remote {
   PROJECT=$1
   PROJECT_PATH=$2
 
+  # Adding logic if file path does not exist
+  cd "$PROJECT_PATH" || {
+    echo "The directory $PROJECT_PATH does not exist. Skipping $PROJECT"
+    echo
+    return
+  }
+
   cd "$PROJECT_PATH"
 
-  ORIGIN_URL="https://github.com/${GH_USER}/${PROJECT}.git"
-  UPSTREAM_URL="https://github.com/doubtfire-lms/${PROJECT}.git"
+  # Adding failure message if origin is not updated
+  ORIGIN_URL="https://github.com/${GH_USER}/${PROJECT}.git" || echo "Script has failed to set origin for $PROJECT"
 
+  # Updating upstream to current repo location and failure message if upstream is not updated
+  UPSTREAM_URL="https://github.com/${UPSTREAM}/${PROJECT}.git" || echo "Script has ailed to set upstream for $PROJECT"
+
+  # Changing output to changing as it will output "echo " - origin is now $ORIGIN_URL"" whether it succeeds or fails 
   echo "Setting up $PROJECT"
-  echo " - origin is now $ORIGIN_URL"
-  echo " - upstream is now $UPSTREAM_URL"
+  echo " - Changing origin to $ORIGIN_URL"
+  echo " - Changing upstream to $UPSTREAM_URL"
   echo
 
   git remote set-url origin "$ORIGIN_URL"


### PR DESCRIPTION
# Description

Making some changes to the change_remotes.sh script to correct filepath logic to work on multiple operating systems and to ask both origin and upstream with checks to confirm the remotes have changed.

https://github.com/thoth-tech/doubtfire-deploy/blob/main/CONTRIBUTING.md
Step 3 will now work correctly

Fixes # 
change_remotes.sh not working on operating systems other than Mac OS and allows for more flexibility on inputs with checks to ensure that the changes to origin and upstream have been made correctly.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran multiple tests to ensure correct origin and upstream are set as well as potential errors to be caught if some repositories are missing and updating text to reflect those changes.

- [x] Tested in git bash on Windows (My only OS)
- [ ] Tested on Mac
- [ ] Tested on Linux

## Checklist

### If involving code

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Folders and Files Added/Modified

Please list the folders and files added/modified with this pull request.

- Modified:
  - [x] doubtfire-deploy/change_remotes.sh

