### PR TITLE
DX-D04: Update contributing setup documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ This guide provides high-level details on how to contribute to the Doubtfire rep
   - [Table of Contents](#table-of-contents)
   - [Getting started](#getting-started)
     - [Development Containers](#development-containers)
+    - [Common setup](#common-setup)
+    - [Working with Dev Containers](#working-with-dev-containers)
     - [Working with Docker Compose](#working-with-docker-compose)
   - [Forking workflow](#forking-workflow)
     - [About the Doubtfire Branch Structure](#about-the-doubtfire-branch-structure)
@@ -27,7 +29,7 @@ This guide provides high-level details on how to contribute to the Doubtfire rep
 The **doubtfire-deploy** project provides the base repository containing submodules for each of the specific subprojects.
 
 - [doubtfire-api](https://github.com/doubtfire-lms/doubtfire-api) contain the backend RESTful API. This uses Rails' [active model](https://guides.rubyonrails.org/active_model_basics.html) with the [Grape REST api framework](https://github.com/ruby-grape/grape).
-- [doubtfire-web](https://github.com/doubtfire-lms/doubtfire-web) hosts the frontend code implemented in [Angular](https://angular.io) and [AngularJS](https://angularjs.org). This implements the web application that connects to the backend api.
+- [doubtfire-web](https://github.com/doubtfire-lms/doubtfire-web) hosts the frontend code implemented in Angular 22. This implements the web application that connects to the backend API.
 - [doubtfire-overseer](https://github.com/doubtfire-lms/doubtfire-overseer) provides facilities to run automated tasks on student submissions. Please get in touch with the core team if you want access to this repository. You can make contributions without access to this repository.
 
 Development of Doubtfire uses Docker containers to remove the need to install a range of native tools used within the project. The Doubtfire Deploy project helps when working across multiple components of the Doubtfire application, and is used for testing and publishing versions for deployment.
@@ -41,84 +43,68 @@ There are several docker compose setups to aid in speeding up the development.
   - The **docker-compose.yml** file contains the most likely setup with development setups for both the api and web projets. This should be used when working on both the api and the web front end. You can run this using **run-api-web.sh**.
   - The **docker-compose.full.yml** contains a setup with all of the containers needed to run Doubtfire with overseer. This requires access to the overseer repository. You can run this using **run-full.sh**
 
-### Working with Dev Containers
+### Common setup
 
-This is the primary method for setting up your development enviroment:
+1. Fork [doubtfire-deploy](https://github.com/doubtfire-lms/doubtfire-deploy), [doubtfire-api](https://github.com/doubtfire-lms/doubtfire-api), and [doubtfire-web](https://github.com/doubtfire-lms/doubtfire-web).
 
-Pre requisittes: Vscode, Docker
-OS: Windows/Linux/Mac OS
-
-1. Fork [doubtfire-deploy](https://github.com/doubtfire-lms/doubtfire-deploy), [doubtfire-api](https://github.com/doubtfire-lms/doubtfire-api), and [doubtfire-web](https://github.com/doubtfire-lms/doubtfire-web)
-
-    To push your contributions, you will need a fork of each repository. Contributions can then be made by making pull requests back into the main repositories.
+   To push your contributions, you will need a fork of each repository. Contributions can then be made by making pull requests back into the main repositories.
 
 2. Clone your [doubtfire-deploy](https://github.com/doubtfire-lms/doubtfire-deploy). Make sure to fetch submodules to get the subprojects.
 
-    `git clone --recurse-submodules https://github.com/YOUR_USERNAME/doubtfire-deploy`
+   `git clone --recurse-submodules https://github.com/YOUR_USERNAME/doubtfire-deploy`
 
-3. Open a Terminal that supports `sh` scripts (on Windows, you will need WSL, Msys2, or Cygwin). Run the following command to set your fork as the remote.
+3. Open a Terminal that supports `sh` scripts (on Windows, you will need WSL, MSYS2, or Cygwin). Run the following command to set your fork as the remote.
 
-    `./change_remotes.sh`
+   `./change_remotes.sh`
 
-4. In Visual studio press F1: Find Dev Containers: Open folder in Container (This will reopen the repo you cloned in a container)
+4. Open a web browser and navigate to:
 
-5. The container will automaticlly setup the DB, Frontend, Backend and your development enviroment ready for use.
+   - [http://localhost:3000/api/docs/](http://localhost:3000/api/docs/) to interact with the API using [Swagger](https://swagger.io).
+   - [http://localhost:4200](http://localhost:4200) to use the web application.
 
-6. Open a web browser and navigate to:
+   The database will include a number of default users, each with password being "password".
 
-    - [http://localhost:3000/api/docs/](http://localhost:3000/api/docs/) to interact with the API using [Swagger](https://swagger.io).
-    - [http://localhost:4200](http://localhost:4200) to use the web application.
+   - Admin user: **aadmin**
+   - Convenor user: **aconvenor**
+   - Tutor user: **atutor**
+   - Students: **student_1**
 
-    The database will include a number of default users, each with password being "password".
-    - Admin user: **aadmin**
-    - Convenor user: **aconvenor**
-    - Tutor user: **atutor**
-    - Students: **student_1**
+### Working with Dev Containers
+
+This is the primary method for setting up your development environment.
+
+Prerequisites: VS Code, Docker
+OS: Windows/Linux/macOS
+
+Follow the [Common setup](#common-setup) steps first, then:
+
+1. In Visual Studio Code, press F1 and select **Dev Containers: Open Folder in Container**. This will reopen the repository you cloned in a container.
+
+2. The container will automatically set up the DB, frontend, backend, and your development environment ready for use.
 
 ### Working with Docker Compose
 
-Alternative setup using Docker-Compose:
+Alternative setup using Docker Compose.
 
-1. Fork [doubtfire-deploy](https://github.com/doubtfire-lms/doubtfire-deploy), [doubtfire-api](https://github.com/doubtfire-lms/doubtfire-api), and [doubtfire-web](https://github.com/doubtfire-lms/doubtfire-web)
+Follow the [Common setup](#common-setup) steps first, then:
 
-    To push your contributions, you will need a fork of each repository. Contributions can then be made by making pull requests back into the main repositories.
+1. Change into the **development** directory and use [Docker Compose](https://docs.docker.com/compose/) to set up the database.
 
-2. Clone your [doubtfire-deploy](https://github.com/doubtfire-lms/doubtfire-deploy). Make sure to fetch submodules to get the subprojects.
+   ```bash
+   cd development
+   docker compose run --rm doubtfire-api bash
+   # now in the container run...
+   bundle exec rails db:environment:set RAILS_ENV=development
+   bundle exec rake db:populate
+   exit
+   ```
 
-    `git clone --recurse-submodules https://github.com/YOUR_USERNAME/doubtfire-deploy`
-
-3. Open a Terminal that supports `sh` scripts (on Windows, you will need WSL, Msys2, or Cygwin). Run the following command to set your fork as the remote.
-
-    `./change_remotes.sh`
-
-4. Change into the **development** directory and use [Docker Compose](https://docs.docker.com/compose/) to setup the database.
-
-    ```bash
-    cd development
-    docker compose run --rm doubtfire-api bash
-    # now in the container run...
-    bundle exec rails db:environment:set RAILS_ENV=development
-    bundle exec rake db:populate
-    exit
-    ```
-
-5. Now you can use `docker compose` to start a running environment.
+2. Use `docker compose` to start a running environment.
 
    ```bash
    # Run in the development folder
    docker compose up
    ```
-
-6. Open a web browser and navigate to:
-
-    - [http://localhost:3000/api/docs/](http://localhost:3000/api/docs/) to interact with the API using [Swagger](https://swagger.io).
-    - [http://localhost:4200](http://localhost:4200) to use the web application.
-
-    The database will include a number of default users, each with password being "password".
-    - Admin user: **aadmin**
-    - Convenor user: **aconvenor**
-    - Tutor user: **atutor**
-    - Students: **student_1**
 
     To interact with the rails console, or other rails command line applications:
 
@@ -134,7 +120,7 @@ Alternative setup using Docker-Compose:
         - Run all unit tests using: `bundle exec rails test`
         - Run tests from a single file: `bundle exec rails test test/models/break_test.rb`
         - Run a single test: `bundle exec rails test test/api/auth_test.rb:107`
-      - Setup the databse:
+      - Set up the databse:
         - Reset the database: `bundle exec rake db:reset db:migrate`
         - Migrate the database on schema changes: `bundle exec rake db:migrate`
         - Add a new migration: `bundle exec rails g migration migration-name`
@@ -152,7 +138,7 @@ Alternative setup using Docker-Compose:
     Some things to know about the setup:
 
     - The containers link to `../data` as a volume to store database details, tmp files, and student work.
-    - If you do not gracefully terminal the api you may need to remove the `pid` file from the tmp folder. You can use `rm ../data/tmp/pids/server.pid` to do this.
+    - If you do not gracefully terminate the API you may need to remove the `pid` file from the tmp folder. You can use `rm ../data/tmp/pids/server.pid` to do this.
     - When you bring up the *doubtfire-web* project, it will run `npm install` to setup the node_modules. If you change the package.json in *doubtfire-web* you can just restart the container to update the node modules.
 
 ## Forking workflow


### PR DESCRIPTION
## Summary

Updates `CONTRIBUTING.md` for DX-D04 to improve and simplify the development setup documentation.

## Changes

- Updated the frontend description from Angular/AngularJS to Angular 22.
- Added `Working with Dev Containers` to the Table of Contents.
- Added a shared `Common setup` section to remove duplicated setup instructions.
- Updated the Dev Containers section to use the shared setup steps and identify Dev Containers as the primary development setup method.
- Updated the Docker Compose section to use the shared setup steps.
- Corrected outdated wording, spelling, and platform terminology, including `VS Code` and `macOS`.
- Updated the Table of Contents to match the revised document structure.

### Documentation reduction

The DX-D04 commit changes `CONTRIBUTING.md` by:

- 39 additions
- 53 deletions
- Net reduction: 14 lines

Verified with:

`git show --numstat --format= HEAD -- CONTRIBUTING.md`

## Validation

### AngularJS reference check

Before the update, `CONTRIBUTING.md` contained an AngularJS reference.

Before:

`git show HEAD^:CONTRIBUTING.md | grep -n "AngularJS"`

After:

`grep -n "AngularJS" CONTRIBUTING.md`

Result: no AngularJS references remain in the updated document.

### Clean checkout Dev Container validation

The Dev Container route was tested end-to-end from a clean checkout.

Validated repository combination:

- API: `11.0.x`
  - Commit: `c6f1592c93961467b9766e67f0ff6154b03bd131`
- Web: `11.0.x`
  - Commit: `c97e793284b84683b149fd5da815c419cd7507ba`
- Deploy: `fix/dx-d04-clean`
  - Commit: `370d8128a509ad60d544cfd022a79e7bf2570ff5`

Submodules were initialized with:

`git submodule update --init --recursive`

The deploy repository was then opened using the VS Code Dev Container route.

Verification inside the Dev Container:

- Workspace opened successfully at `/workspace`.
- `git status --short` returned no changes.
- Web application at `http://localhost:4200` returned `HTTP/1.1 200 OK`.
- API endpoint at `http://localhost:3000/api/settings` returned HTTP `200`.

### Rendered documentation check

The rendered document was reviewed before and after the update.

Confirmed that:

- Shared setup instructions are consolidated under `Common setup`.
- Dev Containers now reference the shared `Common setup`.
- Docker Compose also references the shared `Common setup`.
- Both setup routes remain readable after removing duplicated instructions.

## Repository note

The updated DX-D04 task references `RUNNING-LOCALLY.md`, but that file is not present in the current `11.0.x` deploy repository. The existing repository documentation directs development setup through `CONTRIBUTING.md`, so the clean-checkout validation was completed using the Dev Container route documented there.

## Evidence

### Rendered documentation before
<img width="1470" height="956" alt="before" src="https://github.com/user-attachments/assets/cf276f0c-8887-4445-8bdd-854ecd21f6d0" />

### Rendered documentation after
<img width="1470" height="956" alt="after" src="https://github.com/user-attachments/assets/d8824272-2ea2-456e-838d-06b71924ff91" />
